### PR TITLE
Add ANSI color rendering to MovePlayground output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@tanstack/react-query": "^5.90.12",
         "@uiw/react-codemirror": "^4.25.4",
         "@zktx.io/ptb-builder": "^0.3.29",
-        "@zktx.io/sui-move-builder": "^0.1.0",
+        "@zktx.io/sui-move-builder": "^0.1.1",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
@@ -7009,9 +7009,9 @@
       }
     },
     "node_modules/@zktx.io/sui-move-builder": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@zktx.io/sui-move-builder/-/sui-move-builder-0.1.0.tgz",
-      "integrity": "sha512-sP2ixE9ybaworh4PBkisaMSKAW8QdLy1hwBEOATY7p49V9EyR9CKQp48X3i8xRdH2BIWCTdKkwSaWuSPqcPfVQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@zktx.io/sui-move-builder/-/sui-move-builder-0.1.1.tgz",
+      "integrity": "sha512-qYbc3V7LW9JiuFN05fo+8Kxbq1B6fphVviOs8dmV2CQW6YohygZF2I6T33KRxos2wpCbuhcdCH+1ZKOYhQ8Cmw==",
       "license": "MIT"
     },
     "node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@tanstack/react-query": "^5.90.12",
     "@uiw/react-codemirror": "^4.25.4",
     "@zktx.io/ptb-builder": "^0.3.29",
-    "@zktx.io/sui-move-builder": "^0.1.0",
+    "@zktx.io/sui-move-builder": "^0.1.1",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",


### PR DESCRIPTION
Introduces logic to parse and render ANSI color codes in the MovePlayground output, supporting both light and dark themes. Updates the dependency @zktx.io/sui-move-builder to version 0.1.1 and enables ANSI color output in buildMovePackage.