### PR TITLE
[fix] Migrate to new @zktx.io/sui-move-builder API

### DIFF
--- a/src/components/MovePlayground.tsx
+++ b/src/components/MovePlayground.tsx
@@ -180,9 +180,14 @@ export function MovePlayground() {
     const start = performance.now();
 
     try {
+      // Extract only .move files (exclude README.md, etc.)
+      const sourceFiles = Object.fromEntries(
+        Object.entries(files).filter(([path]) => path.endsWith('.move'))
+      );
+
       const resolution = await resolve(
         files['Move.toml'] ?? '',
-        files,
+        sourceFiles,
         new GitHubFetcher()
       );
 


### PR DESCRIPTION
## Summary

This PR updates the MovePlayground component to work with the new `@zktx.io/sui-move-builder` API, which introduced breaking changes in the dependency resolution and build process.

## Changes

- `src/components/MovePlayground.tsx`
    - Replace `resolveDependencies` with new `resolve` function and `GitHubFetcher` class
    - Update parameter structure: separate `files` and `dependencies` instead of combined `resolvedDependencies`
    - Handle response parsing: convert JSON strings to objects when needed
    - Filter source files to only include `.move` files before passing to `resolve`
    - Update error handling: check `result.success` instead of `"error" in result`
    - Remove `network` parameter which is no longer required by the new API

## Review Points

- Are the changes appropriate for the new API migration?